### PR TITLE
[URECA-27] Feat: Ureca 27/feat/oauth client

### DIFF
--- a/src/main/java/com/ureca/unity/domain/auth/service/OAuthServiceImpl.java
+++ b/src/main/java/com/ureca/unity/domain/auth/service/OAuthServiceImpl.java
@@ -2,13 +2,62 @@ package com.ureca.unity.domain.auth.service;
 
 import com.ureca.unity.domain.auth.constant.OAuthProvider;
 import com.ureca.unity.domain.auth.dto.OAuthLoginResponse;
+import com.ureca.unity.domain.auth.dto.OAuthUserInfo;
+import com.ureca.unity.domain.auth.service.oauth.OAuthClient;
+import com.ureca.unity.domain.user.mapper.UserMapper;
+import com.ureca.unity.domain.user.model.User;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.Map;
+
 @Service
+@RequiredArgsConstructor
 public class OAuthServiceImpl implements OAuthService {
+
+    private final Map<String, OAuthClient> oauthClients;
+    private final UserMapper userMapper;
 
     @Override
     public OAuthLoginResponse login(OAuthProvider provider, String authorizationCode) {
-        throw new UnsupportedOperationException("OAuthService not implemented yet");
+
+        // 1. OAuthClient 선택
+        OAuthClient oAuthClient = oauthClients.get(provider.value());
+        if (oAuthClient == null) {
+            throw new IllegalArgumentException("OAuthClient not found for provider: " + provider);
+        }
+
+        // 2. OAuth 사용자 정보 조회
+        OAuthUserInfo userInfo = oAuthClient.getUserInfo(authorizationCode);
+
+        // 3. 사용자 조회
+        return userMapper
+                .findByProviderAndProviderId(
+                        userInfo.getProvider(),
+                        userInfo.getProviderId()
+                )
+                .map(existingUser ->
+                        OAuthLoginResponse.builder()
+                                .token(null)                // JWT 아직 없음
+                                .requiresOnboarding(false)  // 기존 유저
+                                .build()
+                )
+                .orElseGet(() -> {
+                    // 4. 신규 사용자 생성
+                    User newUser = User.builder()
+                            .provider(userInfo.getProvider())
+                            .providerId(userInfo.getProviderId())
+                            .email(userInfo.getEmail())
+                            .name(userInfo.getName())
+                            .role("ROLE_USER")
+                            .build();
+
+                    userMapper.insert(newUser);
+
+                    return OAuthLoginResponse.builder()
+                            .token(null)
+                            .requiresOnboarding(true)   // 신규 유저
+                            .build();
+                });
     }
 }

--- a/src/main/java/com/ureca/unity/domain/auth/service/oauth/GoogleOAuthClient.java
+++ b/src/main/java/com/ureca/unity/domain/auth/service/oauth/GoogleOAuthClient.java
@@ -1,4 +1,97 @@
 package com.ureca.unity.domain.auth.service.oauth;
 
-public class GoogleOAuthClient {
+import com.ureca.unity.domain.auth.dto.OAuthUserInfo;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Map;
+
+@Component("google")
+@RequiredArgsConstructor
+public class GoogleOAuthClient implements OAuthClient {
+
+    @Value("${oauth.google.client-id}")
+    private String clientId;
+
+    @Value("${oauth.google.client-secret}")
+    private String clientSecret;
+
+    @Value("${oauth.google.token-uri}")
+    private String tokenUri;
+
+    @Value("${oauth.google.user-info-uri}")
+    private String userInfoUri;
+
+    @Value("${oauth.google.redirect-uri}")
+    private String redirectUri;
+
+    private final RestTemplate restTemplate = new RestTemplate();
+
+    @Override
+    public OAuthUserInfo getUserInfo(String authorizationCode) {
+        String accessToken = getAccessToken(authorizationCode);
+        return fetchUserInfo(accessToken);
+    }
+
+    private String getAccessToken(String code) {
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+        body.add("grant_type", "authorization_code");
+        body.add("client_id", clientId);
+        body.add("client_secret", clientSecret);
+        body.add("redirect_uri", redirectUri);
+        body.add("code", code);
+
+        HttpEntity<MultiValueMap<String, String>> request =
+                new HttpEntity<>(body, headers);
+
+        ResponseEntity<Map> response = restTemplate.exchange(
+                tokenUri,
+                HttpMethod.POST,
+                request,
+                Map.class
+        );
+
+        if (response.getBody() == null || response.getBody().get("access_token") == null) {
+            throw new IllegalArgumentException("Failed to retrieve Google access token");
+        }
+
+        return response.getBody().get("access_token").toString();
+    }
+
+    private OAuthUserInfo fetchUserInfo(String accessToken) {
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(accessToken);
+
+        HttpEntity<Void> request = new HttpEntity<>(headers);
+
+        ResponseEntity<Map> response = restTemplate.exchange(
+                userInfoUri,
+                HttpMethod.GET,
+                request,
+                Map.class
+        );
+
+        if (response.getBody() == null || response.getBody().get("id") == null) {
+            throw new IllegalArgumentException("Failed to retrieve Google user info");
+        }
+
+        Map<String, Object> body = response.getBody();
+
+        return OAuthUserInfo.builder()
+                .provider("google")
+                .providerId(body.get("id").toString())
+                .email((String) body.get("email"))   // nullable
+                .name((String) body.get("name"))
+                .build();
+    }
 }

--- a/src/main/java/com/ureca/unity/domain/auth/service/oauth/GoogleOAuthClient.java
+++ b/src/main/java/com/ureca/unity/domain/auth/service/oauth/GoogleOAuthClient.java
@@ -87,6 +87,11 @@ public class GoogleOAuthClient implements OAuthClient {
 
         Map<String, Object> body = response.getBody();
 
+        String name = (String) body.get("name");
+        if (name == null || name.isBlank()) {
+            name = "google_user";
+        }
+
         return OAuthUserInfo.builder()
                 .provider("google")
                 .providerId(body.get("id").toString())

--- a/src/main/java/com/ureca/unity/domain/auth/service/oauth/KakaoOAuthClient.java
+++ b/src/main/java/com/ureca/unity/domain/auth/service/oauth/KakaoOAuthClient.java
@@ -1,4 +1,124 @@
 package com.ureca.unity.domain.auth.service.oauth;
 
-public class KakaoOAuthClient {
+import com.ureca.unity.domain.auth.dto.OAuthUserInfo;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Map;
+
+@Component("kakao")
+@RequiredArgsConstructor
+public class KakaoOAuthClient implements OAuthClient {
+
+    @Value("${oauth.kakao.client-id}")
+    private String clientId;
+
+    // Client Secret 안 쓰는 경우면 application-local.yml에도 없어야 함
+    @Value("${oauth.kakao.client-secret:}")
+    private String clientSecret;
+
+    @Value("${oauth.kakao.token-uri}")
+    private String tokenUri;
+
+    @Value("${oauth.kakao.user-info-uri}")
+    private String userInfoUri;
+
+    @Value("${oauth.kakao.redirect-uri}")
+    private String redirectUri;
+
+    private final RestTemplate restTemplate = new RestTemplate();
+
+    @Override
+    public OAuthUserInfo getUserInfo(String authorizationCode) {
+        String accessToken = getAccessToken(authorizationCode);
+        return fetchUserInfo(accessToken);
+    }
+
+    /* 1. Authorization Code → Access Token */
+    private String getAccessToken(String code) {
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+        body.add("grant_type", "authorization_code");
+        body.add("client_id", clientId);
+        body.add("redirect_uri", redirectUri);
+        body.add("code", code);
+
+        // Client Secret을 쓰는 경우만 포함
+        if (clientSecret != null && !clientSecret.isBlank()) {
+            body.add("client_secret", clientSecret);
+        }
+
+        HttpEntity<MultiValueMap<String, String>> request =
+                new HttpEntity<>(body, headers);
+
+        ResponseEntity<Map> response = restTemplate.exchange(
+                tokenUri,
+                HttpMethod.POST,
+                request,
+                Map.class
+        );
+
+        if (response.getBody() == null || response.getBody().get("access_token") == null) {
+            throw new IllegalArgumentException("Failed to retrieve Kakao access token");
+        }
+
+        return response.getBody().get("access_token").toString();
+    }
+
+    /* 2. Access Token → Kakao User Info */
+    @SuppressWarnings("unchecked")
+    private OAuthUserInfo fetchUserInfo(String accessToken) {
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(accessToken);
+
+        HttpEntity<Void> request = new HttpEntity<>(headers);
+
+        ResponseEntity<Map> response = restTemplate.exchange(
+                userInfoUri,
+                HttpMethod.GET,
+                request,
+                Map.class
+        );
+
+        if (response.getBody() == null || response.getBody().get("id") == null) {
+            throw new IllegalArgumentException("Failed to retrieve Kakao user info");
+        }
+
+        Map<String, Object> body = response.getBody();
+        Map<String, Object> kakaoAccount =
+                (Map<String, Object>) body.get("kakao_account");
+
+        String email = null;
+        String nickname = null;
+
+        if (kakaoAccount != null) {
+            email = (String) kakaoAccount.get("email");
+
+            Map<String, Object> profile =
+                    (Map<String, Object>) kakaoAccount.get("profile");
+            if (profile != null) {
+                nickname = (String) profile.get("nickname");
+            }
+        }
+
+        if (nickname == null || nickname.isBlank()) {
+            nickname = "kakao_user";
+        }
+
+        return OAuthUserInfo.builder()
+                .provider("kakao")
+                .providerId(body.get("id").toString())
+                .email(email)          // nullable (정상)
+                .name(nickname)        // nickname 사용
+                .build();
+    }
 }

--- a/src/main/java/com/ureca/unity/domain/auth/service/oauth/NaverOAuthClient.java
+++ b/src/main/java/com/ureca/unity/domain/auth/service/oauth/NaverOAuthClient.java
@@ -1,4 +1,101 @@
 package com.ureca.unity.domain.auth.service.oauth;
 
-public class NaverOAuthClient {
+import com.ureca.unity.domain.auth.dto.OAuthUserInfo;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Map;
+
+@Component("naver")
+@RequiredArgsConstructor
+public class NaverOAuthClient implements OAuthClient {
+
+    @Value("${oauth.naver.client-id}")
+    private String clientId;
+
+    @Value("${oauth.naver.client-secret}")
+    private String clientSecret;
+
+    @Value("${oauth.naver.token-uri}")
+    private String tokenUri;
+
+    @Value("${oauth.naver.user-info-uri}")
+    private String userInfoUri;
+
+    @Value("${oauth.naver.redirect-uri}")
+    private String redirectUri;
+
+    private final RestTemplate restTemplate = new RestTemplate();
+
+    @Override
+    public OAuthUserInfo getUserInfo(String authorizationCode) {
+        String accessToken = getAccessToken(authorizationCode);
+        return fetchUserInfo(accessToken);
+    }
+
+    /* 1. Authorization Code → Access Token */
+    private String getAccessToken(String code) {
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+        body.add("grant_type", "authorization_code");
+        body.add("client_id", clientId);
+        body.add("client_secret", clientSecret);
+        body.add("redirect_uri", redirectUri);
+        body.add("code", code);
+
+        HttpEntity<MultiValueMap<String, String>> request =
+                new HttpEntity<>(body, headers);
+
+        ResponseEntity<Map> response = restTemplate.exchange(
+                tokenUri,
+                HttpMethod.POST,
+                request,
+                Map.class
+        );
+
+        if (response.getBody() == null || response.getBody().get("access_token") == null) {
+            throw new IllegalArgumentException("Failed to retrieve Naver access token");
+        }
+
+        return response.getBody().get("access_token").toString();
+    }
+
+    /* 2. Access Token → Naver User Info */
+    @SuppressWarnings("unchecked")
+    private OAuthUserInfo fetchUserInfo(String accessToken) {
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(accessToken);
+
+        HttpEntity<Void> request = new HttpEntity<>(headers);
+
+        ResponseEntity<Map> response = restTemplate.exchange(
+                userInfoUri,
+                HttpMethod.GET,
+                request,
+                Map.class
+        );
+
+        if (response.getBody() == null || response.getBody().get("response") == null) {
+            throw new IllegalArgumentException("Failed to retrieve Naver user info");
+        }
+
+        Map<String, Object> responseBody =
+                (Map<String, Object>) response.getBody().get("response");
+
+        return OAuthUserInfo.builder()
+                .provider("naver")
+                .providerId(responseBody.get("id").toString())
+                .email((String) responseBody.get("email"))   // nullable
+                .name((String) responseBody.get("name"))
+                .build();
+    }
 }

--- a/src/main/java/com/ureca/unity/domain/auth/service/oauth/NaverOAuthClient.java
+++ b/src/main/java/com/ureca/unity/domain/auth/service/oauth/NaverOAuthClient.java
@@ -91,6 +91,11 @@ public class NaverOAuthClient implements OAuthClient {
         Map<String, Object> responseBody =
                 (Map<String, Object>) response.getBody().get("response");
 
+        String name = (String) responseBody.get("name");
+        if (name == null || name.isBlank()) {
+            name = "naver_user";
+        }
+
         return OAuthUserInfo.builder()
                 .provider("naver")
                 .providerId(responseBody.get("id").toString())

--- a/src/main/java/com/ureca/unity/domain/auth/service/oauth/OAuthClient.java
+++ b/src/main/java/com/ureca/unity/domain/auth/service/oauth/OAuthClient.java
@@ -1,0 +1,10 @@
+package com.ureca.unity.domain.auth.service.oauth;
+
+import com.ureca.unity.domain.auth.dto.OAuthUserInfo;
+
+/* OAuth 제공자(Google, Naver, Kakao)와의 통신을 담당하는 Client 인터페이스 */
+public interface OAuthClient {
+
+    /*  Authorization Code를 받아 OAuth 사용자 정보를 조회한다. */
+    OAuthUserInfo getUserInfo(String authorizationCode);
+}

--- a/src/main/java/com/ureca/unity/domain/user/mapper/UserMapper.java
+++ b/src/main/java/com/ureca/unity/domain/user/mapper/UserMapper.java
@@ -1,0 +1,17 @@
+package com.ureca.unity.domain.user.mapper;
+
+import com.ureca.unity.domain.user.model.User;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+import java.util.Optional;
+
+@Mapper
+public interface UserMapper {
+
+    Optional<User> findByProviderAndProviderId(
+            @Param("provider") String provider,
+            @Param("providerId") String providerId
+    );
+
+    void insert(User user);
+}

--- a/src/main/java/com/ureca/unity/domain/user/model/User.java
+++ b/src/main/java/com/ureca/unity/domain/user/model/User.java
@@ -1,0 +1,20 @@
+package com.ureca.unity.domain.user.model;
+
+import lombok.*;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class User {
+
+    private Long id;
+
+    private String provider;      // google / naver / kakao
+    private String providerId;    // OAuth 제공자 고유 ID
+
+    private String email;         // nullable
+    private String name;
+
+    private String role;          // ROLE_USER
+}

--- a/src/main/resources/mapper/user/UserMapper.xml
+++ b/src/main/resources/mapper/user/UserMapper.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.ureca.unity.domain.user.mapper.UserMapper">
+
+    <!-- provider + providerId로 사용자 조회 -->
+    <select id="findByProviderAndProviderId"
+            resultType="com.ureca.unity.domain.user.model.User">
+        SELECT
+            id,
+            provider,
+            provider_id AS providerId,
+            email,
+            name,
+            role
+        FROM users
+        WHERE provider = #{provider}
+          AND provider_id = #{providerId}
+    </select>
+
+    <!-- 신규 사용자 insert -->
+    <insert id="insert" useGeneratedKeys="true" keyProperty="id">
+        INSERT INTO users (
+            provider,
+            provider_id,
+            email,
+            name,
+            role
+        ) VALUES (
+                     #{provider},
+                     #{providerId},
+                     #{email},
+                     #{name},
+                     #{role}
+                 )
+    </insert>
+
+</mapper>


### PR DESCRIPTION
## Key Changes

<!--- 바뀐 부분을 간략하게 작성해주세요 -->

- domain/auth/service
- resource/mapper/user

## 작업 내역

<!--- 변경 사항 및 관련 이슈에 대해 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
<!--- 연관된 이슈를 작성해주세요 #(Issue Number) -->

1. Google / Naver / Kakao OAuthClient 구현
  - OAuth 제공자에 대해 Authorization Code → User Info 조회까지 구현했습니다.
  - OAuthClient는 다음 책임만 가집니다.
    -  Access Token 발급
    - 사용자 정보 조회
    - 공통 DTO(OAuthUserInfo)로 변환
  - Kakao의 경우 실명 개념이 없어 nickname이 null일 수 있으므로, DB 제약조건(name NOT NULL)을 만족하기 위해 fallback 처리 로직을 추가했습니다.

2. User 엔티티 생성
  - 사용자 식별 기준은 provider + providerId 복합키 방식입니다.
  - 이메일은 nullable이기 때문입니다. (카카오 때문에 - 카카오는 이메일을 받아올 수 없는 상황입니다.)

3. MyBatis + DB 연동
  - OAuth 로그인 시 DB insert / select 정상 동작 확인하였습니다.
  - DB에 존재하지 않는 신규 회원인 경우 insert
  - DB에 존재하는 기존 회원인 경우 select

4. OAuth 로그인 API (현재는 절반만 구현)
  - 엔드포인트: POST /api/auth/login/{provider}?code=xxx
  - 응답 예시:
    {
      "token": null,
      "requiresOnboarding": true
    }
  - JWT는 다음 이슈에서 구현할 예정입니다.


- close: #13


## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

- OAuthClient란?
  - 외부 OAuth 제공자(Google/Naver/Kakao)와 통신하는 어댑터 역할을 수행합니다.
    - 외부 API 호출(토큰/유저정보)
    - 응답 파싱
    - 우리 서비스가 쓰는 공통 포맷(OAuthUserInfo)으로 정규화
  - 즉, 서비스 내부 로직(User 생성, JWT 발급 등)과는 분리되어 있습니다.

- 제가 알아본 결과, 이번 이슈에서 진행한 방식은 OAuth 2.0 프로토콜을 사용하는 것은 맞으나,
- Spring Security OAuth2 (구현 프레임워크)를 사용하진 않았습니다. -> 해당 방식이 auth를 global/security에 내부에 작성하는 방식이었습니다.
- 그렇다면 auth와 security를 나눈 방식(저희들의 방식)을 채택한 이유는 무엇인가? -> 구글 뿐만이 아니라 네이버, 카카오이 있는 경우엔 응답 처리 방식이 달라 처리를 해주어야 하는데, auth가 security내부에 있는 구조는 해당 과정에서 어려움을 겪게되기 때문입니다.

## 비고

<!--- 추가로 작성하고 싶은 내용이 있다면 적어주세요. -->

1. User 테이블 생성 DDL문
  - 본 PR 테스트를 위해 users 테이블이 필요합니다.
  - 로그인 요청 시 테이블에 회원이 생성됩니다.
  - 로그인 요청 테스트 해보고 싶으신 분은 말씀해주세요. 친절하게 알려드리겠습니다.
```
CREATE TABLE users (
    id BIGINT AUTO_INCREMENT PRIMARY KEY,

    provider VARCHAR(20) NOT NULL,
    provider_id VARCHAR(100) NOT NULL,

    email VARCHAR(255),
    name VARCHAR(100) NOT NULL,

    role VARCHAR(20) NOT NULL,

    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,

    UNIQUE KEY uk_provider_provider_id (provider, provider_id)
);
```

2. application-local.yml은 노션을 참고해주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * OAuth 기반 로그인 흐름 완전 구현
  * Google, Kakao, Naver 소셜 로그인 지원
  * 소셜 계정으로 신규 사용자 자동 가입 및 기존 사용자 자동 인식
  * 소셜 로그인 시 온보딩 유도 기능 추가 (신규 사용자 대상)

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->