### PR TITLE
[URECA-59] Feat: 약관 동의 관련 로직 추가 및 수정

### DIFF
--- a/src/main/java/com/ureca/unity/domain/auth/dto/MeResponse.java
+++ b/src/main/java/com/ureca/unity/domain/auth/dto/MeResponse.java
@@ -3,6 +3,8 @@ package com.ureca.unity.domain.auth.dto;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+import java.time.Instant;
+
 @Getter
 @AllArgsConstructor
 public class MeResponse {
@@ -11,4 +13,7 @@ public class MeResponse {
     private final String name;
     private final String role;
     private final String provider;
+
+    private final boolean termsAgreed;
+    private final Instant termsAgreedAt;
 }

--- a/src/main/java/com/ureca/unity/domain/auth/dto/OAuthLoginResponse.java
+++ b/src/main/java/com/ureca/unity/domain/auth/dto/OAuthLoginResponse.java
@@ -11,4 +11,5 @@ public class OAuthLoginResponse {
 
     private final TokenResponse token;
     private final boolean requiresOnboarding;
+    private final boolean termsAgreed;
 }

--- a/src/main/java/com/ureca/unity/domain/auth/service/AuthSessionServiceImpl.java
+++ b/src/main/java/com/ureca/unity/domain/auth/service/AuthSessionServiceImpl.java
@@ -61,7 +61,9 @@ public class AuthSessionServiceImpl implements AuthSessionService {
                 user.getEmail(),
                 user.getName(),
                 user.getRole(),
-                user.getProvider()
+                user.getProvider(),
+                user.getTermsAgreedAt() != null,
+                user.getTermsAgreedAt()
         );
     }
 

--- a/src/main/java/com/ureca/unity/domain/auth/service/OAuthServiceImpl.java
+++ b/src/main/java/com/ureca/unity/domain/auth/service/OAuthServiceImpl.java
@@ -80,6 +80,11 @@ public class OAuthServiceImpl implements OAuthService {
             OAuthTokenInfo tokenInfo
     ) {
         try {
+            User user = userMapper.findById(userId)
+                    .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+            boolean termsAgreed = user.getTermsAgreedAt() != null;
+
             oAuthTokenService.upsert(
                     OAuthToken.builder()
                             .userId(userId)
@@ -106,6 +111,7 @@ public class OAuthServiceImpl implements OAuthService {
                     OAuthLoginResponse.builder()
                             .token(accessToken)
                             .requiresOnboarding(requiresOnboarding)
+                            .termsAgreed(termsAgreed)
                             .build(),
                     refreshToken
             );

--- a/src/main/java/com/ureca/unity/domain/policy/controller/PolicyController.java
+++ b/src/main/java/com/ureca/unity/domain/policy/controller/PolicyController.java
@@ -1,0 +1,16 @@
+package com.ureca.unity.domain.policy.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+public class PolicyController {
+    @PostMapping("/api/policy/agree")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void agree(Authentication authentication) {
+        Long userId = (Long) authentication.getPrincipal();
+        policyService.agree(userId);
+    }
+
+}

--- a/src/main/java/com/ureca/unity/domain/policy/controller/PolicyController.java
+++ b/src/main/java/com/ureca/unity/domain/policy/controller/PolicyController.java
@@ -1,16 +1,28 @@
 package com.ureca.unity.domain.policy.controller;
 
+import com.ureca.unity.domain.policy.service.PolicyService;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.Authentication;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.*;
 
+@Tag(
+        name = "2. Policy",
+        description = "약관 동의 관련 API"
+)
+@RestController
+@RequestMapping("/api/policy")
+@RequiredArgsConstructor
 public class PolicyController {
-    @PostMapping("/api/policy/agree")
+
+    private final PolicyService policyService;
+
+    @PostMapping("/agree")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void agree(Authentication authentication) {
         Long userId = (Long) authentication.getPrincipal();
         policyService.agree(userId);
     }
-
 }

--- a/src/main/java/com/ureca/unity/domain/policy/service/PolicyService.java
+++ b/src/main/java/com/ureca/unity/domain/policy/service/PolicyService.java
@@ -1,0 +1,4 @@
+package com.ureca.unity.domain.policy.service;
+
+public class PolicyService {
+}

--- a/src/main/java/com/ureca/unity/domain/policy/service/PolicyService.java
+++ b/src/main/java/com/ureca/unity/domain/policy/service/PolicyService.java
@@ -1,4 +1,5 @@
 package com.ureca.unity.domain.policy.service;
 
-public class PolicyService {
+public interface PolicyService {
+    void agree(Long userId);
 }

--- a/src/main/java/com/ureca/unity/domain/policy/service/PolicyServiceImpl.java
+++ b/src/main/java/com/ureca/unity/domain/policy/service/PolicyServiceImpl.java
@@ -1,4 +1,30 @@
 package com.ureca.unity.domain.policy.service;
 
-public class PolicyServiceImpl {
+import com.ureca.unity.domain.user.mapper.UserMapper;
+import com.ureca.unity.domain.user.model.User;
+import com.ureca.unity.global.exception.CustomException;
+import com.ureca.unity.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+
+@Service
+@RequiredArgsConstructor
+public class PolicyServiceImpl implements PolicyService {
+
+    private final UserMapper userMapper;
+
+    @Override
+    public void agree(Long userId) {
+        User user = userMapper.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        // 이미 동의했으면 아무 것도 안 함 (멱등성)
+        if (user.getTermsAgreedAt() != null) {
+            return;
+        }
+
+        userMapper.updateTermsAgreedAt(userId, Instant.now());
+    }
 }

--- a/src/main/java/com/ureca/unity/domain/policy/service/PolicyServiceImpl.java
+++ b/src/main/java/com/ureca/unity/domain/policy/service/PolicyServiceImpl.java
@@ -6,6 +6,7 @@ import com.ureca.unity.global.exception.CustomException;
 import com.ureca.unity.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Instant;
 
@@ -16,6 +17,7 @@ public class PolicyServiceImpl implements PolicyService {
     private final UserMapper userMapper;
 
     @Override
+    @Transactional
     public void agree(Long userId) {
         User user = userMapper.findById(userId)
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));

--- a/src/main/java/com/ureca/unity/domain/policy/service/PolicyServiceImpl.java
+++ b/src/main/java/com/ureca/unity/domain/policy/service/PolicyServiceImpl.java
@@ -1,0 +1,4 @@
+package com.ureca.unity.domain.policy.service;
+
+public class PolicyServiceImpl {
+}

--- a/src/main/java/com/ureca/unity/domain/user/mapper/UserMapper.java
+++ b/src/main/java/com/ureca/unity/domain/user/mapper/UserMapper.java
@@ -3,6 +3,8 @@ package com.ureca.unity.domain.user.mapper;
 import com.ureca.unity.domain.user.model.User;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
+
+import java.time.Instant;
 import java.util.Optional;
 
 @Mapper
@@ -30,4 +32,10 @@ public interface UserMapper {
             @Param("email") String email,
             @Param("name") String name
     );
+
+    int updateTermsAgreedAt(
+            @Param("userId") Long userId,
+            @Param("termsAgreedAt") Instant termsAgreedAt
+    );
+
 }

--- a/src/main/java/com/ureca/unity/domain/user/model/User.java
+++ b/src/main/java/com/ureca/unity/domain/user/model/User.java
@@ -2,6 +2,7 @@ package com.ureca.unity.domain.user.model;
 
 import lombok.*;
 
+import java.time.Instant;
 import java.time.LocalDateTime;
 
 @Getter
@@ -20,5 +21,6 @@ public class User {
 
     private String role;          // ROLE_USER
 
+    private Instant termsAgreedAt;
     private LocalDateTime deletedAt;
 }

--- a/src/main/resources/mapper/user/UserMapper.xml
+++ b/src/main/resources/mapper/user/UserMapper.xml
@@ -88,6 +88,7 @@
         UPDATE users
         SET terms_agreed_at = #{termsAgreedAt}
         WHERE user_id = #{userId}
+          AND deleted_at IS NULL
     </update>
 
 

--- a/src/main/resources/mapper/user/UserMapper.xml
+++ b/src/main/resources/mapper/user/UserMapper.xml
@@ -13,7 +13,8 @@
             provider_id AS providerId,
             email,
             name,
-            role
+            role,
+            terms_agreed_at AS termsAgreedAt
         FROM users
         WHERE provider = #{provider}
           AND provider_id = #{providerId}
@@ -43,7 +44,8 @@
             provider_id AS providerId,
             email,
             name,
-            role
+            role,
+            terms_agreed_at AS termsAgreedAt
         FROM users
         WHERE user_id = #{userId}
           AND deleted_at IS NULL
@@ -65,6 +67,7 @@
             email,
             name,
             role,
+            terms_agreed_at AS termsAgreedAt,
             deleted_at AS deletedAt
         FROM users
         WHERE provider = #{provider}
@@ -76,8 +79,16 @@
         SET
             deleted_at = NULL,
             email = #{email},
-            name = #{name}
+            name = #{name},
+            terms_agreed_at = NULL
         WHERE user_id = #{userId}
     </update>
+
+    <update id="updateTermsAgreedAt">
+        UPDATE users
+        SET terms_agreed_at = #{termsAgreedAt}
+        WHERE user_id = #{userId}
+    </update>
+
 
 </mapper>


### PR DESCRIPTION
## Key Changes

<!--- 바뀐 부분을 간략하게 작성해주세요 -->

- domain/policy/

## 작업 내역

<!--- 변경 사항 및 관련 이슈에 대해 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
<!--- 연관된 이슈를 작성해주세요 #(Issue Number) -->

- users 테이블에 해당 사용자가 동의 했는지 여부를 확인하기 위한 terms_agree_at 컬럼 추가
- 프론트엔드에서 약관동의 페이지 분기를 위해서 login 응답에 terms_agree_at 관련 정보 추가
- 약관 페이지에서 동의하기 버튼을 눌렀을 때 terms_agree_at에 동의 시간을 입력하는 /policy/agree API 구현

- close: #36 


## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

- users 테이블에 terms_agree_at 컬럼을 추가하기 위한 ALTER문을 추가하였습니다. (노션 참고 부탁드립니다.)
```sql
ALTER TABLE users
ADD COLUMN terms_agreed_at TIMESTAMP NULL;
```

## 비고

<!--- 추가로 작성하고 싶은 내용이 있다면 적어주세요. -->

-

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

**새로운 기능**
- 약관 동의 API 추가: 사용자가 정책에 동의할 수 있는 엔드포인트 제공.
- 약관 동의 기록 저장: 사용자의 동의 여부 및 동의 시각이 저장됩니다.
- 사용자·로그인 응답 반영: 계정 조회 및 로그인 응답에 약관 동의 상태와 동의 시간이 포함됩니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->